### PR TITLE
🚸 simplify behavior when closing fédération logos

### DIFF
--- a/DorisAndroid/src/main/java/fr/ffessm/doris/android/activities/SplashScreen_CustomViewActivity.java
+++ b/DorisAndroid/src/main/java/fr/ffessm/doris/android/activities/SplashScreen_CustomViewActivity.java
@@ -137,6 +137,8 @@ public class SplashScreen_CustomViewActivity extends OrmLiteActionBarActivity<Or
 
                     SharedPreferences.Editor ed = prefs.edit();
                     ed.putBoolean(getString(R.string.pref_key_debug_maj_base_prochain_demarrage), false);
+                    // force fede icons on update of the application
+                    ed.putBoolean(getString(R.string.pref_key_accueil_aff_iconesfede), true);
                     ed.apply();
                 }
 

--- a/DorisAndroid/src/main/res/values/accueil_customview_strings.xml
+++ b/DorisAndroid/src/main/res/values/accueil_customview_strings.xml
@@ -35,7 +35,7 @@
 	<string name="accueil_customview_logo_doris_url">http://doris.ffessm.fr</string>
 	<string name="accueil_customview_logo_bio_description">Logo Biologie Accueil</string>
 	<string name="accueil_customview_logo_bio_url">http://biologie.ffessm.fr</string>
-	<string name="accueil_customview_logos_preference">"Il est possible de masquer par défaut ce bandeau dans les préférences."</string>
+	<string name="accueil_customview_logos_preference">"Vous pouvez rétablir ce bandeau via les préférences."</string>
 	
 	<string name="menu_option_telecharge_photofiches">Précharg. photos M/A</string>
 	<string name="menu_option_maj_listesfiches">MaJ listes fiches</string>

--- a/DorisAndroid/src/main/res/values/preference_strings.xml
+++ b/DorisAndroid/src/main/res/values/preference_strings.xml
@@ -262,14 +262,14 @@
         <item>Très Grandes</item>
     </string-array>
     
-	<string name="pref_accueil_aff_iconesfede_prompt">Affichage Icônes Fédé.\u00A0?</string>
-	<string name="pref_accueil_aff_iconesfede_summary">"Masquer permet de gagner de la place sur l'écran d'accueil"</string>
+	<string name="pref_accueil_aff_iconesfede_prompt">Affichage Logos Fédé.\u00A0?</string>
+    <string name="pref_accueil_aff_iconesfede_summary" />
 	
 	<string name="pref_fiche_aff_details_pardefaut_prompt">Fiche\u00A0: montrer détails\u00A0?</string>
 	<string name="pref_fiche_aff_details_pardefaut_summary">"Les détails de la fiche sont tous affichés par défaut"</string>
 	
 	<string name="pref_imagepleinecran_aff_zoomcontrol_prompt">Afficher boutons de contrôle de zoom</string>
-	<string name="pref_imagepleinecran_aff_zoomcontrol_summary"></string>
+	<string name="pref_imagepleinecran_aff_zoomcontrol_summary"/>
 	
 	<string name="imagepleinecran_titre_longmax">25</string>
 		


### PR DESCRIPTION
- closing the logo action remains active until next application update
- action in the preference view is immediately taken into account

closes #192