### PR TITLE
Workaround for missing let's encrypt certificate on device with <= api 24

### DIFF
--- a/DorisAndroid/build.gradle
+++ b/DorisAndroid/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.preference:preference:1.2.1'
     implementation "com.squareup.picasso:picasso:2.71828"
+    implementation 'com.squareup.okhttp3:okhttp:5.1.0'
     implementation 'com.google.android.material:material:1.12.0'
 
     constraints {

--- a/DorisAndroid/src/main/java/fr/ffessm/doris/android/activities/ImagePleinEcran_Adapter.java
+++ b/DorisAndroid/src/main/java/fr/ffessm/doris/android/activities/ImagePleinEcran_Adapter.java
@@ -260,7 +260,7 @@ public class ImagePleinEcran_Adapter extends PagerAdapter {
 
                             @Override
                             public void onError(Exception e) {
-                                Log.e(LOG_TAG, "onError: "+requestedImage);
+                                Log.e(LOG_TAG, "onError: "+requestedImage, e);
                                 btnHiResNotAvailable.setVisibility(View.VISIBLE);
                             }
                         });

--- a/DorisAndroid/src/main/java/fr/ffessm/doris/android/activities/view/AffichageMessageHTML.java
+++ b/DorisAndroid/src/main/java/fr/ffessm/doris/android/activities/view/AffichageMessageHTML.java
@@ -41,6 +41,7 @@ termes.
 * ********************************************************************* */
 package fr.ffessm.doris.android.activities.view;
 
+import android.os.Build;
 import android.widget.ImageView;
 
 import com.j256.ormlite.dao.CloseableIterator;
@@ -243,6 +244,12 @@ public class AffichageMessageHTML {
         texte.append(nbFichesProposees + context.getString(R.string.a_propos_base_nb_fiches_redaction));
         texte.append((fichesOutils.getNbFichesZoneGeo(Constants.ZoneGeographiqueKind.FAUNE_FLORE_TOUTES_ZONES) - (nbFichesPubliees + nbFichesProposees))
                 + context.getString(R.string.a_propos_base_nb_fiches_proposées));
-        return texte.toString();
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N) {
+            texte.append("\n");
+            texte.append(context.getString(R.string.a_propos_ssl_compatibility_mode_activated));
+        }
+
+            return texte.toString();
     }
 }

--- a/DorisAndroid/src/main/java/fr/ffessm/doris/android/tools/UnsafeOkHttpClientUtil.java
+++ b/DorisAndroid/src/main/java/fr/ffessm/doris/android/tools/UnsafeOkHttpClientUtil.java
@@ -1,0 +1,89 @@
+package fr.ffessm.doris.android.tools;
+
+import android.os.Build;
+import android.util.Log;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.OkHttpClient;
+
+/**
+ * Class used to workaround Let's Encrypt invalid certificate chain on Android 6 (Marshmallow) and bellow
+ * UNSAFE ! MUST NOT BE USED IN ANY OTHER ANDROID VERSION THAN THESE ONES
+ */
+public class UnsafeOkHttpClientUtil {
+    private static final String LOG_TAG = UnsafeOkHttpClientUtil.class.getSimpleName();
+
+
+    // --- Singleton Instance ---
+    private static volatile OkHttpClient sInstance = null;
+
+    // Private constructor to prevent instantiation
+    private UnsafeOkHttpClientUtil() {}
+
+    public static OkHttpClient getOkHTTPClientInstance() {
+        if (sInstance == null) {
+            synchronized (UnsafeOkHttpClientUtil.class) {
+                if (sInstance == null) {
+                    sInstance = createCustomOkHttpClient();
+                }
+            }
+        }
+        return sInstance;
+    }
+
+    private static OkHttpClient createCustomOkHttpClient() {
+        // --- Condition: Apply only for Android versions Nougat (API 24) and older ---
+        // Adjust this SDK check as per your needs for Let's Encrypt / specific SSL issues
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N) { // N is API 24 (Nougat 6.0)
+            Log.w(LOG_TAG, "Applying unsafe SSLSocketFactory for OkHttpClient on Android API " + Build.VERSION.SDK_INT);
+            try {
+                final TrustManager[] trustAllCerts = new TrustManager[]{
+                        new X509TrustManager() {
+                            @Override
+                            public void checkClientTrusted(java.security.cert.X509Certificate[] x509Certificates, String s) throws java.security.cert.CertificateException {
+                            }
+
+                            @Override
+                            public void checkServerTrusted(java.security.cert.X509Certificate[] x509Certificates, String s) throws java.security.cert.CertificateException {
+                            }
+
+                            @Override
+                            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                                return new java.security.cert.X509Certificate[0];
+                            }
+
+                        }
+                };
+                final SSLContext sslContext = SSLContext.getInstance("SSL");
+                sslContext.init(null, trustAllCerts, new SecureRandom());
+                final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+
+                OkHttpClient.Builder builder = new OkHttpClient.Builder();
+                builder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustAllCerts[0]);
+                builder.hostnameVerifier(new HostnameVerifier() {
+                    @Override
+                    public boolean verify(String hostname, SSLSession session) {
+                        return true;
+                    }
+                });
+                return builder.build();
+            } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                Log.e(LOG_TAG, "Failed to create unsafe SSLSocketFactory for Picasso", e);
+                return new OkHttpClient.Builder().build(); // Fallback
+            }
+        } else {
+            Log.d(LOG_TAG, "Using standard OkHttpClient for Picasso on Android API " + Build.VERSION.SDK_INT);
+            return new OkHttpClient.Builder().build();
+        }
+    }
+}

--- a/DorisAndroid/src/main/res/raw/apropos.html
+++ b/DorisAndroid/src/main/res/raw/apropos.html
@@ -46,7 +46,8 @@
 				<li><a href="https://doris.ffessm.fr/A-propos-de-DORIS">Qu'est-ce que DORIS ?</a></li>
 				<li><a href="https://doris-ffessm.github.io">Site DorisAndroid</a></li>
 				<li><a href="https://doris-ffessm.github.io/all_news">News DorisAndroid</a></li>
-				<li><a href="https://doris.ffessm.fr/FAQ">Foire Aux Questions DORIS ?</a></li>
+				<li><a href="https://doris-ffessm.github.io/#faq">Foire Aux Questions DORISAndroid</a></li>
+				<li><a href="https://doris.ffessm.fr/FAQ">Foire Aux Questions DORIS</a></li>
 				<li><a href="https://doris.ffessm.fr/Mentions-legales">Copyright (Licence DORIS) </a></li>
 			</ul>
 		</div>
@@ -74,6 +75,7 @@
 				- Simplification gestion bandeau des logos fédéraux (<a href="https://github.com/doris-ffessm/doris-android/issues/192">#192</a>)<br/>
 				- Amélioration navigation entre modes d'affichage des listes de fiche (<a href="https://github.com/doris-ffessm/doris-android/issues/176">#176</a>,
 					<a href="https://github.com/doris-ffessm/doris-android/issues/220">#220</a>)<br/>
+				- Ajout mode de compatibilité SSL pour les anciens téléphones (<a href="https://github.com/doris-ffessm/doris-android/issues/226">#226</a>)<br/>
 				- Amélioration image de base pour certains groupes (<a href="https://github.com/doris-ffessm/doris-android/issues/186">#186</a>)<br/>
 			</span>
 			<h4>Version 4.11.2 - 07/2025</h4>

--- a/DorisAndroid/src/main/res/values/apropos_aide_strings.xml
+++ b/DorisAndroid/src/main/res/values/apropos_aide_strings.xml
@@ -11,6 +11,7 @@
 	<string name="a_propos_base_nb_fiches_publiees">" fiches complètes, "</string>
 	<string name="a_propos_base_nb_fiches_redaction">" en cours de rédaction et "</string>
 	<string name="a_propos_base_nb_fiches_proposées">" proposées"</string>
+	<string name="a_propos_ssl_compatibility_mode_activated">"Mode compatibilité SSL activé."</string>
 		
 	<string name="aide_menu">Aide</string>
 	<string name="aide_label">Guide Utilisateur</string>


### PR DESCRIPTION
On older device we disable the ssl certificate verification since the certificates used by https://doris.ffessm.fr  doesn't provide a supported root certificate anymore.

The patch applies only on device with API <= 24, a message is provided in the about box to warn the user + a link to the FAQ page explaining the issue.


The risk remains limited because:
- the number on affected devices is very low (<10 according to google play console)
- the app downloads only images from a single source : https://doris.ffessm.fr

<img width="510" height="988" alt="image" src="https://github.com/user-attachments/assets/419a7f85-c3dd-43bc-b238-e405ed15196f" />


a real fix would require to assist the user in adding the certificate by themselves but this is probably much more complex ...

closes #226